### PR TITLE
fix error when value is null

### DIFF
--- a/lib/circle_progress_bar.dart
+++ b/lib/circle_progress_bar.dart
@@ -51,7 +51,7 @@ class CircleProgressBarState extends State<CircleProgressBar>
     // Build the initial required tweens.
     this.valueTween = Tween<double>(
       begin: 0,
-      end: this.widget.value,
+      end: this.widget.value != null ? this.widget.value : 0,
     );
 
     this._controller.forward();


### PR DESCRIPTION
════════ Exception caught by widgets library ═══════════════════════════════════
The following assertion was thrown building AnimatedBuilder(animation: AnimationController#3c9db(▶ 0.517)➩Cubic(0.42, 0.00, 0.58, 1.00), dirty, state: _AnimatedState#6df98):
'package:flutter/src/animation/tween.dart': Failed assertion: line 259 pos 12: 'end != null': is not true.


Either the assertion indicates an error in the framework itself, or we should provide substantially more information in this error message to help you determine and fix the underlying cause.
In either case, please report this assertion by filing a bug on GitHub:
  https://github.com/flutter/flutter/issues/new?template=BUG.md